### PR TITLE
Add `--timeout` (`-t`) argument

### DIFF
--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -124,6 +124,8 @@ def main(comments, **extra_opts):
     :param bool buffer_size: file buffer size in bytes
     :param bool search_comment_body: search comment body for mal url
         if no flair?
+    :param int timeout: Timeout after n seconds if comment source hasn't
+        already been depleted
     """
     # Assign default values if options not specified
     buffer_size = extra_opts.get("buffer_size", DEFAULTS.BUFFER_SIZE)

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -159,6 +159,7 @@ def main(comments, **extra_opts):
         for comment in comments:
             if (time.time() - start_time) >= timeout:
                 # Timeout exceeded. Stop processing any more comments
+                logger.info("Timeout exceeded. Not processing any more comments.")
                 break
 
             if not comment.author or comment.author.name in processed:

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -129,6 +129,7 @@ def main(comments, **extra_opts):
     buffer_size = extra_opts.get("buffer_size", DEFAULTS.BUFFER_SIZE)
     search_comment_body = extra_opts.get("search_comment_body",
                                          DEFAULTS.SEARCH_COMMENT_BODY)
+    timeout = extra_opts.get("timeout", DEFAULTS.TIMEOUT)
 
     processed = set()
 
@@ -156,6 +157,10 @@ def main(comments, **extra_opts):
 
     try:
         for comment in comments:
+            if (time.time() - start_time) >= timeout:
+                # Timeout exceeded. Stop processing any more comments
+                break
+
             if not comment.author or comment.author.name in processed:
                 continue
 
@@ -264,7 +269,7 @@ if __name__ == "__main__":
     group3.add_argument(
         "-b", "--search-comment-body",
         help=("search the comment body for a mal url if a user "
-             "doesn't have a flair"),
+              "doesn't have a flair"),
         action="store_true",
         default=DEFAULTS.SEARCH_COMMENT_BODY
     )
@@ -274,6 +279,13 @@ if __name__ == "__main__":
               "bytes to hold in buffer before writing to file (default: 512)."
               " assume the average row to be written is around 30-35 bytes"),
         metavar="SIZE", default=DEFAULTS.BUFFER_SIZE, type=int
+    )
+    group3.add_argument(
+        "-t", "--timeout",
+        help=("terminate the script after a specified amount of time "
+              "(in seconds), if the comment source hasn't already been "
+              "fully processed by then (default: never)"),
+        default=DEFAULTS.TIMEOUT, type=int
     )
 
     args = parser.parse_args()

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -124,7 +124,7 @@ def main(comments, **extra_opts):
     :param bool buffer_size: file buffer size in bytes
     :param bool search_comment_body: search comment body for mal url
         if no flair?
-    :param int timeout: Timeout after n seconds if comment source hasn't
+    :param int timeout: timeout after n seconds if comment source hasn't
         already been depleted
     """
     # Assign default values if options not specified

--- a/soulmate_finder/const.py
+++ b/soulmate_finder/const.py
@@ -6,6 +6,7 @@ class DEFAULTS:
     FTF_LIMIT = 5
     QUIET = False
     SEARCH_COMMENT_BODY = False
+    TIMEOUT = 9e999  # (inf)
     VERBOSE = False
 
 HEADERS = ["reddit", "mal", "affinity", "shared"]


### PR DESCRIPTION
```python
>>> timeit.timeit('time.time() - 1508073963.527385 >= 9e999', setup="import time", number=100000)
0.016883312382333315
```

```python
>>> timeit.timeit('time.time() - 1508073963.527385 >= math.inf', setup="import time, math", number=100000)
0.020471211762810526
```

Doesn't seem to make much of a difference re performance.