### PR TITLE
Reduce the default `FTF_LIMIT` to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ comment sources:
   -f [LIMIT], --ftf [LIMIT]
                         use the comments in ftfs as the comment source.
                         `LIMIT` specifies how many ftfs to use, working
-                        backwards from the current one (default: 5)
+                        backwards from the current one (default: 1)
 
 logging/print options:
   controls the level of verbosity for this script

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -243,7 +243,7 @@ if __name__ == "__main__":
         "-f", "--ftf",
         help=("use the comments in ftfs as the comment source. "
               "`LIMIT` specifies how many ftfs to use, working backwards "
-              "from the current one (default: 5)"),
+              "from the current one (default: 1)"),
         metavar="LIMIT",
         nargs="?", const=DEFAULTS.FTF_LIMIT, type=int
     )

--- a/soulmate_finder/const.py
+++ b/soulmate_finder/const.py
@@ -3,7 +3,7 @@ VERSION = "4.5.0.dev0"
 
 class DEFAULTS:
     BUFFER_SIZE = 512
-    FTF_LIMIT = 5
+    FTF_LIMIT = 1
     QUIET = False
     SEARCH_COMMENT_BODY = False
     TIMEOUT = 9e999  # (inf)


### PR DESCRIPTION
5 FTFs is too much, 1 should do. `LIMIT` can still be specified, which'll override the default.