### PR TITLE
Allow the subreddit for the comment stream to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ optional arguments:
 comment sources:
   source of comments, which will be processed
 
-  -c, --stream          use the comment stream as the comment source
+  -c, --stream          use the /r/anime comment stream as the comment source
   -s SUBMISSION_ID, --submission SUBMISSION_ID
                         use the comments in a submission as the comment
                         source. `SUBMISSION_ID` is the reddit submission id (6

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
 
     # Choose either comment stream or comments from submission.
     if args.stream:
-        comments = sources.comment_stream()
+        comments = sources.comment_stream(args.stream)
     elif args.submission:
         comments = sources.submission(args.submission)
     elif args.ftf:

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -15,11 +15,8 @@ if __name__ == "__main__":
     mxg = group.add_mutually_exclusive_group(required=True)
     mxg.add_argument(
         "-c", "--stream",
-        help=("use the comment stream from a subreddit as the comment source. "
-              "`SUBREDDIT` is the name of the subreddit to use, without the "
-              "/r/ prefix (default: anime)"),
-        metavar="SUBREDDIT", nargs="?",
-        const=DEFAULTS.STREAM_SUBREDDIT, type=str
+        help="use the comment stream as the comment source",
+        action="store_true"
     )
     mxg.add_argument(
         "-s", "--submission",

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
     mxg.add_argument(
         "-c", "--stream",
         help="use the /r/anime comment stream as the comment source",
-        action="store_true"
+        action="store_const", const=DEFAULTS.STREAM_SUBREDDIT
     )
     mxg.add_argument(
         "-s", "--submission",
@@ -86,7 +86,7 @@ if __name__ == "__main__":
 
     # Choose either comment stream or comments from submission.
     if args.stream:
-        comments = sources.comment_stream()
+        comments = sources.comment_stream(args.stream)
     elif args.submission:
         comments = sources.submission(args.submission)
     elif args.ftf:

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     mxg = group.add_mutually_exclusive_group(required=True)
     mxg.add_argument(
         "-c", "--stream",
-        help="use the comment stream as the comment source",
+        help="use the /r/anime comment stream as the comment source",
         action="store_true"
     )
     mxg.add_argument(
@@ -86,7 +86,7 @@ if __name__ == "__main__":
 
     # Choose either comment stream or comments from submission.
     if args.stream:
-        comments = sources.comment_stream(args.stream)
+        comments = sources.comment_stream()
     elif args.submission:
         comments = sources.submission(args.submission)
     elif args.ftf:

--- a/soulmate_finder/__main__.py
+++ b/soulmate_finder/__main__.py
@@ -15,8 +15,11 @@ if __name__ == "__main__":
     mxg = group.add_mutually_exclusive_group(required=True)
     mxg.add_argument(
         "-c", "--stream",
-        help="use the comment stream as the comment source",
-        action="store_true"
+        help=("use the comment stream from a subreddit as the comment source. "
+              "`SUBREDDIT` is the name of the subreddit to use, without the "
+              "/r/ prefix (default: anime)"),
+        metavar="SUBREDDIT", nargs="?",
+        const=DEFAULTS.STREAM_SUBREDDIT, type=str
     )
     mxg.add_argument(
         "-s", "--submission",

--- a/soulmate_finder/const.py
+++ b/soulmate_finder/const.py
@@ -6,6 +6,7 @@ class DEFAULTS:
     FTF_LIMIT = 1
     QUIET = False
     SEARCH_COMMENT_BODY = False
+    STREAM_SUBREDDIT = "anime"
     TIMEOUT = 9e999  # (inf)
     VERBOSE = False
 

--- a/soulmate_finder/sources.py
+++ b/soulmate_finder/sources.py
@@ -52,10 +52,10 @@ def _create_reddit_instance():
     return praw.Reddit("reddit", user_agent=const.REDDIT_USER_AGENT)
 
 
-def comment_stream():
+def comment_stream(subreddit="anime"):
     reddit = _create_reddit_instance()
 
-    return reddit.subreddit("anime").stream.comments()
+    return reddit.subreddit(subreddit).stream.comments()
 
 
 def submission(submission_id):

--- a/soulmate_finder/sources.py
+++ b/soulmate_finder/sources.py
@@ -52,7 +52,7 @@ def _create_reddit_instance():
     return praw.Reddit("reddit", user_agent=const.REDDIT_USER_AGENT)
 
 
-def comment_stream(subreddit="anime"):
+def comment_stream(subreddit=const.DEFAULTS.STREAM_SUBREDDIT):
     reddit = _create_reddit_instance()
 
     return reddit.subreddit(subreddit).stream.comments()


### PR DESCRIPTION
Subreddit can be modified if package imported manually, but won't be possible from the argparse args, because there's not really much point in allowing it to be specified there (no other subreddits have MAL URLs in users' flairs AFAIK - this'd probably only be used for testing if I get around to writing tests for this package)